### PR TITLE
Handle multiple rounds

### DIFF
--- a/contracts/Market.sol
+++ b/contracts/Market.sol
@@ -8,34 +8,37 @@ interface IERC721{
 
 
 contract Market{
-    
+
     event Sale(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     event Listing(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     event Unlisting(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     address public admin;  // The admin can reset the token contract after each new round
     address public pendingAdmin; // the pending admin in case admin transfers ownership
-    mapping(bytes32 => bytes32) public listings; // all listings 
+    mapping(bytes32 => bytes32) public listings; // all listings
     mapping(uint256 => IERC721) public contracts; // the different token contracts supported
     uint256 numContracts;
-    
+
     constructor(address tokensAddress){
         admin = msg.sender; // admin can upgrade to new rounds
-        contracts[0] = IERC721(tokensAddress);  
+        contracts[0] = IERC721(tokensAddress);
     }
 
 
@@ -62,8 +65,8 @@ contract Market{
         sendValue(payable(seller), msg.value);
         emit Sale(tokenID,msg.value,contractNo);
     }
-    
-    
+
+
     // Unlist a token you listed
     // Useful if you want your tokens back
     function unlist (uint256 price, uint256 id ,bytes32 listingHash, uint256 contractNo) external {
@@ -74,10 +77,10 @@ contract Market{
     }
 
 
-    // ADMIN 
+    // ADMIN
     // Change the tokens address between rounds
     // WARNING: the trust given to admin is quite high.
-    
+
     // This function is where the danger is.
     // If admin adds a custom contract that isn't actually ERC721 but instead does something possibly bad
     // TODO: find out the severity of the bad things admin could do

--- a/contracts/Market_WithListing.sol
+++ b/contracts/Market_WithListing.sol
@@ -18,7 +18,7 @@ contract Market{
         uint256 indexed id,
         uint256 indexed price,
         uint256 indexed round,
-        address seller
+        address seller // maybe have this be buyer instead
     );
 
     event Listed(
@@ -61,7 +61,7 @@ contract Market{
         });
 
         contracts[contractNo].transferFrom(msg.sender, address(this), tokenID);
-        emit Listed(tokenID,price,contractNo);
+        emit Listed(tokenID,price,,msg.sender);
     }
 
     // buying function. User input is the price they pay
@@ -72,7 +72,7 @@ contract Market{
         require (msg.value == oldListing.buyoutPrice, "wrong value");
         contracts[contractNo].transferFrom(address(this), msg.sender, tokenID);
         sendValue(payable(oldListing.owner), oldListing.buyoutPrice);
-        emit Sale(tokenID,msg.value,contractNo);
+        emit Sale(tokenID,msg.value,contractNo,oldListing.owner);
     }
 
 
@@ -83,7 +83,7 @@ contract Market{
         require(msg.sender == holder);
         delete listings[listingHash];
         contracts[contractNo].transferFrom(address(this), msg.sender, id);
-        emit Unlisting(id,price,contractNo);
+        emit Unlisting(id,price,contractNo,msg.sender);
     }
 
 

--- a/contracts/Market_WithListing.sol
+++ b/contracts/Market_WithListing.sol
@@ -68,6 +68,7 @@ contract Market{
     function buy(bytes32 listingHash, uint256 contractNo, uint256 tokenID) external payable  {
         Listing memory oldListing = listings[listingHash];
         delete listings[listingHash];
+        require (keccak256(abi.encode(tokenID,contractNo)) == listingHash, "incorrect params");
         require (msg.value == oldListing.buyoutPrice, "wrong value");
         contracts[contractNo].transferFrom(address(this), msg.sender, tokenID);
         sendValue(payable(oldListing.owner), oldListing.buyoutPrice);

--- a/contracts/Market_WithListing.sol
+++ b/contracts/Market_WithListing.sol
@@ -8,39 +8,42 @@ interface IERC721{
 
 
 contract Market{
-    
+
     struct Listing{
         address owner;       // who owns the listed artifact
         uint256 buyoutPrice; // price of the artifact in xdai
     }
-    
+
     event Sale(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     event Listed(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     event Unlisting(
         uint256 indexed id,
         uint256 indexed price,
-        uint256 indexed round
+        uint256 indexed round,
+        address seller
     );
-    
+
     address public admin;  // The admin can reset the token contract after each new round
     address public pendingAdmin; // the pending admin in case admin transfers ownership
     mapping(bytes32 => Listing) public listings; // all listings     mapping(uint256 => IERC721) public contracts; // the different token contracts supported
     mapping(uint256 => IERC721) public contracts; // the different token contracts supported
     uint256 numContracts;
-    
+
     constructor(address tokensAddress){
         admin = msg.sender; // admin can upgrade to new rounds
-        contracts[0] = IERC721(tokensAddress);  
+        contracts[0] = IERC721(tokensAddress);
     }
 
 
@@ -56,7 +59,7 @@ contract Market{
             owner: msg.sender,
             buyoutPrice: price
         });
-        
+
         contracts[contractNo].transferFrom(msg.sender, address(this), tokenID);
         emit Listed(tokenID,price,contractNo);
     }
@@ -70,8 +73,8 @@ contract Market{
         sendValue(payable(oldListing.owner), oldListing.buyoutPrice);
         emit Sale(tokenID,msg.value,contractNo);
     }
-    
-    
+
+
     // Unlist a token you listed
     // Useful if you want your tokens back
     function unlist (uint256 price, uint256 id ,bytes32 listingHash, uint256 contractNo) external {
@@ -83,10 +86,10 @@ contract Market{
     }
 
 
-    // ADMIN 
+    // ADMIN
     // Change the tokens address between rounds
     // WARNING: the trust given to admin is quite high.
-    
+
     // This function is where the danger is.
     // If admin adds a custom contract that isn't actually ERC721 but instead does something possibly bad
     // TODO: find out the severity of the bad things admin could do

--- a/contracts/Market_WithListing.sol
+++ b/contracts/Market_WithListing.sol
@@ -1,0 +1,110 @@
+//SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.7;
+
+interface IERC721{
+    function transferFrom(address from, address to, uint256 tokenID) external;
+}
+
+
+contract Market{
+    
+    struct Listing{
+        address owner;       // who owns the listed artifact
+        uint256 buyoutPrice; // price of the artifact in xdai
+    }
+    
+    event Sale(
+        uint256 indexed id,
+        uint256 indexed price,
+        uint256 indexed round
+    );
+    
+    event Listed(
+        uint256 indexed id,
+        uint256 indexed price,
+        uint256 indexed round
+    );
+    
+    event Unlisting(
+        uint256 indexed id,
+        uint256 indexed price,
+        uint256 indexed round
+    );
+    
+    address public admin;  // The admin can reset the token contract after each new round
+    address public pendingAdmin; // the pending admin in case admin transfers ownership
+    mapping(bytes32 => Listing) public listings; // all listings     mapping(uint256 => IERC721) public contracts; // the different token contracts supported
+    mapping(uint256 => IERC721) public contracts; // the different token contracts supported
+    uint256 numContracts;
+    
+    constructor(address tokensAddress){
+        admin = msg.sender; // admin can upgrade to new rounds
+        contracts[0] = IERC721(tokensAddress);  
+    }
+
+
+    // sendValue from openZeppelin Address library https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/Address.sol
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+        (bool success, ) = recipient.call{value: amount}("");
+        require(success, "Address: unable to send value, recipient may have reverted");
+    }
+
+    function list(uint256 tokenID, uint256 price, uint256 contractNo) external  {
+        listings[keccak256(abi.encode(tokenID,contractNo))] = Listing({
+            owner: msg.sender,
+            buyoutPrice: price
+        });
+        
+        contracts[contractNo].transferFrom(msg.sender, address(this), tokenID);
+        emit Listed(tokenID,price,contractNo);
+    }
+
+    // buying function. User input is the price they pay
+    function buy(bytes32 listingHash, uint256 contractNo, uint256 tokenID) external payable  {
+        Listing memory oldListing = listings[listingHash];
+        delete listings[listingHash];
+        require (msg.value == oldListing.buyoutPrice, "wrong value");
+        contracts[contractNo].transferFrom(address(this), msg.sender, tokenID);
+        sendValue(payable(oldListing.owner), oldListing.buyoutPrice);
+        emit Sale(tokenID,msg.value,contractNo);
+    }
+    
+    
+    // Unlist a token you listed
+    // Useful if you want your tokens back
+    function unlist (uint256 price, uint256 id ,bytes32 listingHash, uint256 contractNo) external {
+        address holder = listings[listingHash].owner;
+        require(msg.sender == holder);
+        delete listings[listingHash];
+        contracts[contractNo].transferFrom(address(this), msg.sender, id);
+        emit Unlisting(id,price,contractNo);
+    }
+
+
+    // ADMIN 
+    // Change the tokens address between rounds
+    // WARNING: the trust given to admin is quite high.
+    
+    // This function is where the danger is.
+    // If admin adds a custom contract that isn't actually ERC721 but instead does something possibly bad
+    // TODO: find out the severity of the bad things admin could do
+    function addContract(address tokens) external{
+        numContracts++;
+        require(msg.sender == admin, "admin function only");
+        contracts[numContracts] = IERC721(tokens);
+    }
+
+    function giveOwnership(address newOwner) external{
+        require(msg.sender == admin, "admin function only");
+        pendingAdmin = newOwner;
+    }
+
+    function acceptOwnership() external{
+        require(msg.sender == pendingAdmin, "you are not the pending admin");
+        admin = pendingAdmin;
+    }
+
+}
+

--- a/subgraph/subgraph.yaml
+++ b/subgraph/subgraph.yaml
@@ -8,7 +8,7 @@ dataSources:
     name: Market
     network: xdai
     source:
-      address: "0x3Fb840EbD1fFdD592228f7d23e9CA8D55F72F2F8"
+      address: "0x3Fb840EbD1fFdD592228f7d23e9CA8D55F72F2F8" # need some way of having multiple subgraphs 
       abi: Market
       startBlock: 16895824
     mapping:


### PR DESCRIPTION
Its my opinion that the plugin should only show current round artifacts, whereas the dapp could show them from all rounds.  
I'm not exactly a UI designer; but you could either have all the artifacts display at once or have seperate pages for each.  
Maybe there could be an updated smart contract that an admin can add new token contracts to. Each listing would probably then need a 'round' property.
Regardless of how the updated contract looks I have to change up the subgraph so old rounds AND current round artifacts are visible.